### PR TITLE
Fixed bug at line 391 of sketch ds_ui.ino

### DIFF
--- a/DollyShield/ds_ui.ino
+++ b/DollyShield/ds_ui.ino
@@ -388,7 +388,8 @@ void ui_button_center( boolean held ) {
         // the next menu to go to
         
           // calibration, don't do anything else
-      if( (cur_menu == 2 || cur_menu == 3) && cur_pos == 6 ) {
+          // EJD:20130329: Corregido && cur_pos == 6 que no dejaba acceder a calibrar la constante 
+      if( (cur_menu == 2 || cur_menu == 3) && cur_pos == 5 ) {
         get_value(cur_menu, cur_pos, false);
         return;
       }

--- a/README.md
+++ b/README.md
@@ -7,3 +7,6 @@ This version of the firmware is ready for compiling in Arduino 1.0+
 
 For more information, see http://dynamicperception.com
 
+MX2 Firmware 0.92
+=================
+EJD:20130329: Fixed bug at line 391 of sketch ds_ui.ino that not allowed to change the value of the calibration constant


### PR DESCRIPTION
# MX2 Firmware 0.92

EJD:20130329: Fixed bug at line 391 of sketch ds_ui.ino that not allowed
to change the value of the calibration constant
